### PR TITLE
chore: tell eslint to ignore test snapshots

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,4 @@
 node_modules
 local
 dist
+test/__snapshots__


### PR DESCRIPTION
Adds `test/__snapshots` directory to list of files ignored by eslint.