### PR TITLE
fix: update arguments to createFactory helper

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1206,9 +1206,9 @@
       }
     },
     "@volusion/element-block-utils": {
-      "version": "1.0.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/@volusion/element-block-utils/-/element-block-utils-1.0.0-alpha.3.tgz",
-      "integrity": "sha512-BHy7kapOthk4GrrWrLboj0KVB9ZxUwegl3Vh9NsSvXpCbJpdSMKmao+dFHepXX1mQckcclpE7BTFCSeBwDNKLA==",
+      "version": "1.0.0-alpha.4",
+      "resolved": "https://registry.npmjs.org/@volusion/element-block-utils/-/element-block-utils-1.0.0-alpha.4.tgz",
+      "integrity": "sha512-l0AhiveCftBAEH0Ri//V6bpFc9LM61KHQUAy+HrlrpfpItJoUov1U2Kh+qMKasyDYPdq5L4eJTZ9wSgh2paU/w==",
       "dev": true
     },
     "@volusion/element-proptypes": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1206,9 +1206,9 @@
       }
     },
     "@volusion/element-block-utils": {
-      "version": "1.0.0-alpha.1",
-      "resolved": "https://registry.npmjs.org/@volusion/element-block-utils/-/element-block-utils-1.0.0-alpha.1.tgz",
-      "integrity": "sha512-d3QQSzQ/uijNIwbivre4E3EdLvZOCBsmHoc2/SN2P4NmO9oNpWpwt6Z4mvxT1Fq6LHXQxI5u6GbxCFfjMfcfYg==",
+      "version": "1.0.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/@volusion/element-block-utils/-/element-block-utils-1.0.0-alpha.3.tgz",
+      "integrity": "sha512-BHy7kapOthk4GrrWrLboj0KVB9ZxUwegl3Vh9NsSvXpCbJpdSMKmao+dFHepXX1mQckcclpE7BTFCSeBwDNKLA==",
       "dev": true
     },
     "@volusion/element-proptypes": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "dependencies": {},
   "devDependencies": {
     "@volusion/element-block-scripts": "1.0.0-alpha.0",
-    "@volusion/element-block-utils": "^1.0.0-alpha.1",
+    "@volusion/element-block-utils": "^1.0.0-alpha.3",
     "@volusion/element-proptypes": "^1.0.12"
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "dependencies": {},
   "devDependencies": {
     "@volusion/element-block-scripts": "1.0.0-alpha.0",
-    "@volusion/element-block-utils": "^1.0.0-alpha.3",
+    "@volusion/element-block-utils": "^1.0.0-alpha.4",
     "@volusion/element-proptypes": "^1.0.12"
   }
 }

--- a/src/configs.js
+++ b/src/configs.js
@@ -1,4 +1,4 @@
-export const configSchema = ElementPropTypes => {
+export const getConfigSchema = ElementPropTypes => {
     return {
         text: {
             label: 'Text content',

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,6 @@ import { getStyles } from './getStyles';
 import { configSchema, defaultConfig } from './configs';
 import { getDataProps } from './getDataProps';
 
-const factory = createFactory(StarterBlockFactory, getStyles, configSchema);
+const factory = createFactory(StarterBlockFactory, { getStyles, configSchema });
 
 export { factory, getDataProps, defaultConfig };

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,9 @@
 import { createFactory } from '@volusion/element-block-utils';
 import { StarterBlockFactory } from './Block';
 import { getStyles } from './getStyles';
-import { configSchema, defaultConfig } from './configs';
+import { getConfigSchema, defaultConfig } from './configs';
 import { getDataProps } from './getDataProps';
 
-const factory = createFactory(StarterBlockFactory, { getStyles, configSchema });
+const factory = createFactory(StarterBlockFactory, { getStyles, getConfigSchema });
 
 export { factory, getDataProps, defaultConfig };


### PR DESCRIPTION
Updates createFactory helper to match breaking-change update in element-block-utils package.

Function signature for `createFactory()` changed: 
**OLD:** `createFactory(blockFactory, getStyles, configSchema)`
**NEW:** `createFactory(blockFactory, { getStyles, configSchema })`