### PR TITLE
refactor: add example params to functions

### DIFF
--- a/src/getDataProps.js
+++ b/src/getDataProps.js
@@ -1,1 +1,1 @@
-export const getDataProps = () => Promise.resolve();
+export const getDataProps = (utils, props) => Promise.resolve();

--- a/src/getStyles.js
+++ b/src/getStyles.js
@@ -1,1 +1,1 @@
-export const getStyles = () => ({});
+export const getStyles = (globalStyles, blockConfig) => ({});


### PR DESCRIPTION
- adds paramaters to `getStyles` and `getDataProps` to demonstrate what
  arguments they will be passed when they are called.

The starter block doesn't have a linter in place yet, so this doesn't currently trigger any lint errors.