### PR TITLE
test: Suppress Aphrodite StyleSheet injection

### DIFF
--- a/__test__/Block.spec.js
+++ b/__test__/Block.spec.js
@@ -1,18 +1,17 @@
 import React from 'react';
 import { StyleSheet, css } from 'aphrodite';
-import { ElementPropTypes } from '@volusion/element-proptypes'
+import { ElementPropTypes } from '@volusion/element-proptypes';
 import { configure, shallow, mount } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 configure({ adapter: new Adapter() });
 
-import { block as Block } from '../src/'
+import { block as Block } from '../src/';
 import { defaultConfig } from '../src/configs';
 
 describe('The Starter Block', () => {
-
     it('renders without errors', () => {
-      mount(<Block />)
-    })
+        mount(<Block />);
+    });
 
     describe('when there is no custom data', () => {
         it('should render the block with the default content', () => {

--- a/__test__/Block.spec.js
+++ b/__test__/Block.spec.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { StyleSheet, css } from 'aphrodite';
+import { StyleSheet, css, StyleSheetTestUtils } from 'aphrodite';
 import { ElementPropTypes } from '@volusion/element-proptypes';
 import { configure, shallow, mount } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
@@ -9,6 +9,8 @@ import { block as Block } from '../src/';
 import { defaultConfig } from '../src/configs';
 
 describe('The Starter Block', () => {
+    StyleSheetTestUtils.suppressStyleInjection();
+
     it('renders without errors', () => {
         mount(<Block />);
     });

--- a/__test__/Block.spec.js
+++ b/__test__/Block.spec.js
@@ -8,7 +8,7 @@ configure({ adapter: new Adapter() });
 import { block as Block } from '../src/';
 import { defaultConfig } from '../src/configs';
 
-describe('The Starter Block', () => {
+describe('The Block', () => {
     StyleSheetTestUtils.suppressStyleInjection();
 
     it('renders without errors', () => {

--- a/src/Block.js
+++ b/src/Block.js
@@ -2,10 +2,10 @@ import React from 'react';
 
 import { defaultConfig } from './configs';
 
-function StarterBlock(props) {
+function Block(props) {
     return <h1>{props.text}</h1>;
 }
 
-StarterBlock.defaultProps = defaultConfig;
+Block.defaultProps = defaultConfig;
 
-export default StarterBlock;
+export default Block;

--- a/src/Block.js
+++ b/src/Block.js
@@ -2,9 +2,9 @@ import React from 'react';
 
 import { defaultConfig } from './configs';
 
-function Block(props) {
+const Block = props => {
     return <h1>{props.text}</h1>;
-}
+};
 
 Block.defaultProps = defaultConfig;
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,3 @@
-import block from './Block';
-import { configSchema, defaultConfig } from './configs';
-import { getDataProps } from './getDataProps';
-
-export { block, getDataProps, defaultConfig, configSchema };
+export { default as block } from './Block';
+export { configSchema, defaultConfig } from './configs';
+export { getDataProps } from './getDataProps';


### PR DESCRIPTION
- Ensures test pass if you add Aphrodite classes to your block (bb840103196b6f44f0539eb94e2741c64b3d9ad3).
- Lints test file.
- Renames "StarterBlock" references to "Block"
- Simplifies import > export syntax to "export from" syntax.
- Converts Block function to arrow syntax.