### PR TITLE
[V2E-646]remove current query params from canonicalUrl

### DIFF
--- a/local/index.js
+++ b/local/index.js
@@ -39,8 +39,7 @@ const createQueryParams = () => {
     return params;
 };
 const canonicalUrl = (newQueryParams = {}) => {
-    const currentQueryParams = createQueryParams();
-    const allQueries = { ...currentQueryParams, ...newQueryParams };
+    const allQueries = {...newQueryParams};
     const joinedQueries = Object.keys(allQueries)
         .map(queryName => `${queryName}=${allQueries[queryName]}`)
         .join('&');

--- a/local/index.js
+++ b/local/index.js
@@ -38,10 +38,9 @@ const createQueryParams = () => {
     }
     return params;
 };
-const canonicalUrl = (newQueryParams = {}) => {
-    const allQueries = {...newQueryParams};
-    const joinedQueries = Object.keys(allQueries)
-        .map(queryName => `${queryName}=${allQueries[queryName]}`)
+const canonicalUrl = (queryParams = {}) => {
+    const joinedQueries = Object.keys(queryParams)
+        .map(queryName => `${queryName}=${queryParams[queryName]}`)
         .join('&');
     const queryString = joinedQueries ? '?' + joinedQueries : '';
     return window.location.origin + queryString;


### PR DESCRIPTION
removes current query parameters from automatically feeding into canonicalUrl