### PR TITLE
fix(local-env): Mocks missing utils.

### DIFF
--- a/local/index.js
+++ b/local/index.js
@@ -76,6 +76,11 @@ const addAmpScript = customElement => {
     }
 };
 
+const throwNotFound = () =>
+    console.error(
+        `"throwNotFound()" was called. On a live site, this would load a 404 page.`
+    );
+
 const {
     joinClasses,
     ElementPropTypes,
@@ -91,6 +96,7 @@ const serverUtils = {
     addLink,
     addScript,
     isAmpRequest,
+    throwNotFound
 };
 
 const dataUtils = {

--- a/local/index.js
+++ b/local/index.js
@@ -64,18 +64,22 @@ const {
     ...sdkUtils
 } = window.ElementSdk;
 
+const serverUtils = {
+    addLink
+};
+
 const dataUtils = {
     isRendering: true
 };
 
 const utils = {
     ...sdkUtils,
+    ...serverUtils,
     pubSub: PubSub.PubSub,
     isAmpRequest: /googleamp/i.test(window.location.pathname)
         ? true
         : undefined,
-    canonicalUrl,
-    addLink
+    canonicalUrl
 };
 
 const props = {

--- a/local/index.js
+++ b/local/index.js
@@ -82,12 +82,15 @@ const {
     Components,
     hydrateBlocks,
     PubSub,
+    addScript,
     ...sdkUtils
 } = window.ElementSdk;
 
 const serverUtils = {
     addAmpScript,
-    addLink
+    addLink,
+    addScript,
+    isAmpRequest,
 };
 
 const dataUtils = {
@@ -98,7 +101,6 @@ const utils = {
     ...sdkUtils,
     ...serverUtils,
     pubSub: PubSub.PubSub,
-    isAmpRequest,
     canonicalUrl
 };
 

--- a/local/index.js
+++ b/local/index.js
@@ -55,6 +55,27 @@ const addLink = href => {
     document.head.appendChild(link);
 };
 
+const isAmpRequest = /googleamp/i.test(window.location.pathname)
+    ? true
+    : undefined;
+
+const addAmpScript = customElement => {
+    if (isAmpRequest) {
+        const script = document.createElement('script');
+        script.setAttribute('async', '');
+        script.setAttribute('custom-element', customElement);
+        script.setAttribute(
+            'src',
+            `https://cdn.ampproject.org/v0/${customElement}-0.1.js`
+        );
+        document.head.appendChild(script);
+    } else {
+        console.error(
+            `"addAmpScript" is only available on AMP pages. Please check if "isAmpRequest" is true before using this function.`
+        );
+    }
+};
+
 const {
     joinClasses,
     ElementPropTypes,
@@ -65,6 +86,7 @@ const {
 } = window.ElementSdk;
 
 const serverUtils = {
+    addAmpScript,
     addLink
 };
 
@@ -76,9 +98,7 @@ const utils = {
     ...sdkUtils,
     ...serverUtils,
     pubSub: PubSub.PubSub,
-    isAmpRequest: /googleamp/i.test(window.location.pathname)
-        ? true
-        : undefined,
+    isAmpRequest,
     canonicalUrl
 };
 

--- a/local/index.js
+++ b/local/index.js
@@ -122,7 +122,7 @@ function configureBlock(data = {}) {
     const block = blockModule.block;
     return React.createElement(block, {
         ...props,
-        clientUtils,
+        utils: { ...clientUtils, ...serverUtils },
         joinClasses,
         data
     });

--- a/local/index.js
+++ b/local/index.js
@@ -103,7 +103,7 @@ const dataUtils = {
     isRendering: true
 };
 
-const utils = {
+const clientUtils = {
     ...sdkUtils,
     ...serverUtils,
     pubSub: PubSub.PubSub,
@@ -118,7 +118,12 @@ const props = {
 
 function configureBlock(data = {}) {
     const block = blockModule.block;
-    return React.createElement(block, { ...props, utils, joinClasses, data });
+    return React.createElement(block, {
+        ...props,
+        clientUtils,
+        joinClasses,
+        data
+    });
 }
 
 function renderBlock(data) {
@@ -129,5 +134,5 @@ function renderBlock(data) {
 
 window.onload = () =>
     blockModule
-        .getDataProps({ ...utils, ...dataUtils }, { ...props })
+        .getDataProps({ ...clientUtils, ...dataUtils }, { ...props })
         .then(renderBlock);

--- a/local/index.js
+++ b/local/index.js
@@ -81,6 +81,7 @@ const throwNotFound = () =>
         `"throwNotFound()" was called. On a live site, this would load a 404 page.`
     );
 
+/* eslint-disable no-unused-vars */
 const {
     joinClasses,
     ElementPropTypes,
@@ -90,6 +91,7 @@ const {
     addScript,
     ...sdkUtils
 } = window.ElementSdk;
+/* eslint-enable no-unused-vars */
 
 const serverUtils = {
     addAmpScript,

--- a/local/index.js
+++ b/local/index.js
@@ -134,5 +134,8 @@ function renderBlock(data) {
 
 window.onload = () =>
     blockModule
-        .getDataProps({ ...clientUtils, ...dataUtils }, { ...props })
+        .getDataProps(
+            { ...clientUtils, ...serverUtils, ...dataUtils },
+            { ...props }
+        )
         .then(renderBlock);

--- a/local/index.js
+++ b/local/index.js
@@ -64,7 +64,7 @@ const {
     ...sdkUtils
 } = window.ElementSdk;
 
-const serverUtils = {
+const dataUtils = {
     isRendering: true
 };
 
@@ -97,5 +97,5 @@ function renderBlock(data) {
 
 window.onload = () =>
     blockModule
-        .getDataProps({ ...utils, ...serverUtils }, { ...props })
+        .getDataProps({ ...utils, ...dataUtils }, { ...props })
         .then(renderBlock);

--- a/local/index.js
+++ b/local/index.js
@@ -47,6 +47,13 @@ const canonicalUrl = (newQueryParams = {}) => {
     const queryString = joinedQueries ? '?' + joinedQueries : '';
     return window.location.origin + queryString;
 };
+const addLink = href => {
+    const link = document.createElement('link');
+    link.setAttribute('type', 'text/css');
+    link.setAttribute('rel', 'stylesheet');
+    link.setAttribute('href', href);
+    document.head.appendChild(link);
+};
 
 const {
     joinClasses,
@@ -67,7 +74,8 @@ const utils = {
     isAmpRequest: /googleamp/i.test(window.location.pathname)
         ? true
         : undefined,
-    canonicalUrl
+    canonicalUrl,
+    addLink
 };
 
 const props = {


### PR DESCRIPTION
- Splits out client utils, server utils, and utils that only appear in getDataProps.
- Adds eslint ignore comments around unused deconstructed utils.