### PR TITLE
feat: Updates getStyles function and adds example usage.

### DIFF
--- a/src/Block.js
+++ b/src/Block.js
@@ -1,9 +1,12 @@
 import React from 'react';
+import { css, StyleSheet } from 'aphrodite';
+import { getStyles } from './getStyles';
 
 import { defaultConfig } from './configs';
 
 const Block = props => {
-    return <h1>{props.text}</h1>;
+    const classes = StyleSheet.create(getStyles(props));
+    return <h1 className={css(classes.example)}>{props.text}</h1>;
 };
 
 Block.defaultProps = defaultConfig;

--- a/src/getStyles.js
+++ b/src/getStyles.js
@@ -1,1 +1,5 @@
-export const getStyles = blockConfig => ({});
+export const getStyles = blockConfig => ({
+    example: {
+        fontSize: '2rem'
+    }
+});

--- a/src/getStyles.js
+++ b/src/getStyles.js
@@ -1,1 +1,1 @@
-export const getStyles = (globalStyles, blockConfig) => ({});
+export const getStyles = blockConfig => ({});


### PR DESCRIPTION
- Removes `globalProps` argument from `getStyles` function. Now that global styles are no longer accessible in the new block contract, and aphrodite classes are created manually within the block, there's no reason to have two arguments in the `getStyles` function.
- Adds example usage of using aphrodite classes so devs do not need to rely on finding the relevant docs to use them.