### PR TITLE
chore: Updates readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ We use this repo to provide a common starting point for all blocks. Good news --
 
 ## How
 
-From the Element CLI, run `element new BLOCKNAME` and that tool will take care of the rest!
+From the Element CLI, run `element new <BlockDirectoryName>` and that tool will take care of the rest!
 
 ## Development
 
@@ -41,6 +41,60 @@ As a developer, if you've made changes to your already-published block, you may 
 
 ```bash
 npm test -- -u
+```
+
+You can also run a watch task that will automatically run your tests any time you make a change to your code:
+
+```bash
+npm test
+```
+
+## Deployment
+
+### Compiling
+
+If you have made changes to your block code, you'll need to recompile your code locally. **This command should be done every time you run one of the below `element` commands.**
+
+```bash
+npm run build
+```
+
+### Initial publishing
+
+If this is the very first time you're pushing your block up, you will need to run the command below (including the quotes):
+
+```bash
+npm run build && element publish -n "<Your Displayed Block Name>"
+```
+
+At this point, your block is in a "staging" state. You can preview your block in Site Designer and through the Preview link in Site Designer, but it will not be visible on the live site.
+
+### Minor updates
+
+After your block has been published the first time, if you are making a minor version change (like a bug fix):
+
+```bash
+npm run build && element update
+```
+
+At this point, your block is in a "staging" state. You can preview your changes in Site Designer and through the Preview link in Site Designer, but they will not be visible on the live site.
+
+### Major updates
+
+If you have a breaking change that you need to make, you can use the below command. Before taking this step, we recommend you create a new branch from master for your old version block code in case you ever need to go back to make minor updates again.
+
+```bash
+npm run build && element publish -m
+```
+
+If you need to make additional updates after this point, you can use the `npm run build && element update` command to stage your changes.
+
+### Releasing to production
+
+Once you have QA'd your block updates in Site Designer and the Preview link, you can release your code to production using the below command. **If you have made minor updates only (you have NOT run `element publish -m`), these changes will immediately take effect on the live site.**
+
+```bash
+element release
 ```
 
 ## Code of Conduct

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ If this is the very first time you're pushing your block up, you will need to ru
 npm run build && element publish -n "<Your Displayed Block Name>"
 ```
 
-At this point, your block is in a "staging" state. You can preview your block in Site Designer and through the Preview link in Site Designer, but it will not be visible on the live site.
+-   At this point, your block is in a "staging" state. You can preview your block in Site Designer and on the storefront through the Preview link in Site Designer, but it will not be visible on the live site.
 
 ### Minor updates
 
@@ -77,7 +77,7 @@ After your block has been published the first time, if you are making a minor ve
 npm run build && element update
 ```
 
-At this point, your block is in a "staging" state. You can preview your changes in Site Designer and through the Preview link in Site Designer, but they will not be visible on the live site.
+-   At this point, your block is in a "staging" state. You can preview your changes in Site Designer and on the storefront through the Preview link in Site Designer, but they will not be visible on the live site.
 
 ### Major updates
 
@@ -87,11 +87,12 @@ If you have a breaking change that you need to make, you can use the below comma
 npm run build && element publish -m
 ```
 
-If you need to make additional updates after this point, you can use the `npm run build && element update` command to stage your changes.
+-   At this point, your block is in a "staging" state. You can preview your changes in Site Designer and on the storefront through the Preview link in Site Designer, but they will not be visible on the live site.
+-   If you need to make additional updates after this point, you can use the `npm run build && element update` command to stage your changes.
 
 ### Releasing to production
 
-Once you have QA'd your block updates in Site Designer and the Preview link, you can release your code to production using the below command. **If you have made minor updates only (you have NOT run `element publish -m`), these changes will immediately take effect on the live site.**
+Once you have completed your QA process on your block updates in Site Designer and the Preview link, you can release your code to production using the below command. **If you have made minor updates only (you have NOT run `element publish -m`), these changes will immediately take effect on the live site.**
 
 ```bash
 element release


### PR DESCRIPTION
- Adds block update/release process.

- I debated on adding this vs adding a link to the documentation. Since the documentation URL might be changing, I opted to put duplicate documentation in the readme instead of causing 404 links.