### PR TITLE
Add repository field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,5 +15,9 @@
         "@volusion/element-block-scripts": "^2.2.3",
         "@volusion/element-block-utils": "^1.1.4",
         "@volusion/element-proptypes": "^1.1.2"
+    },
+    "repository": {
+      "type": "git",
+      "url": "git://github.com/volusion/element-BlockStarter.git"
     }
 }


### PR DESCRIPTION
To eliminate warning on npm install for [no repository field](https://stackoverflow.com/questions/16827858/npm-warn-package-json-no-repository-field): 
```
C:\dev\ElementDemoBlock  (@volusion/element-block-starter@1.0.3)
λ npm i
npm WARN @volusion/element-block-starter@1.0.3 No repository field.
```

Tested locally and this change fixes the missing repository warning.