### PR TITLE
feat: Updates blockStarter for AMP

### DIFF
--- a/__test__/AMP.spec.js
+++ b/__test__/AMP.spec.js
@@ -1,0 +1,35 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import {
+    mockUtils as utils,
+    joinClasses
+} from '@volusion/element-block-utils/test-utils';
+import { block as Block, defaultConfig } from '../src';
+
+let props;
+describe('The Block when loaded over AMP', () => {
+    beforeEach(() => {
+        props = {
+            data: {},
+            utils: { ...utils, isAmpRequest: true },
+            joinClasses,
+            queryParams: {}
+        };
+    });
+    it('renders without errors', () => {
+        mount(<Block {...props} />);
+    });
+    describe('when there is no custom data', () => {
+        it('should render the block with the default content', () => {
+            const wrapper = mount(<Block {...props} />);
+            expect(wrapper.text()).toBe(defaultConfig.text);
+        });
+    });
+    describe('when given custom data', () => {
+        it('should render the block using the custom data', () => {
+            const customText = 'Custom Block Text';
+            const wrapper = mount(<Block {...props} text={customText} />);
+            expect(wrapper.text()).toBe(customText);
+        });
+    });
+});

--- a/__test__/Block.spec.js
+++ b/__test__/Block.spec.js
@@ -9,7 +9,7 @@ import { block as Block, defaultConfig } from '../src';
 let props;
 describe('The Block', () => {
     beforeEach(() => {
-        props = { utils, joinClasses };
+        props = { data: {}, utils, joinClasses, queryParams: {} };
     });
     it('renders without errors', () => {
         mount(<Block {...props} />);

--- a/__test__/Block.spec.js
+++ b/__test__/Block.spec.js
@@ -9,7 +9,12 @@ import { block as Block, defaultConfig } from '../src';
 let props;
 describe('The Block', () => {
     beforeEach(() => {
-        props = { data: {}, utils, joinClasses, queryParams: {} };
+        props = {
+            data: {},
+            utils,
+            joinClasses,
+            queryParams: {}
+        };
     });
     it('renders without errors', () => {
         mount(<Block {...props} />);

--- a/local/googleamp/index.html
+++ b/local/googleamp/index.html
@@ -96,8 +96,42 @@
                 }
             </style></noscript
         >
+        <style amp-custom>
+            .local-env-banner {
+                background-color: #4285f4;
+                color: white;
+            }
+            .local-env-btn {
+                padding: 0.5rem 1rem;
+                border-radius: 5px;
+                border: 2px solid white;
+                background-color: inherit;
+                color: white;
+                font-weight: bold;
+                white-space: nowrap;
+            }
+            .local-env-btn:hover {
+                background-color: white;
+                color: #4285f4;
+            }
+        </style>
     </head>
     <body>
-        <div id="root"></div>
+        <div
+            class="local-env-banner flex items-center flex-wrap flex-nowrap-ns justify-between"
+        >
+            <div class="pa3">
+                <a href="../"
+                    ><button class="local-env-btn">View non-AMP page</button></a
+                >
+            </div>
+            <div class="dn db-l pa3">
+                Due to the nature of local environments, you cannot test full
+                AMP compliance without staging your block. This page serves as a
+                means of verifying your canonicalUrls and AMP elements are
+                functioning correctly.
+            </div>
+        </div>
+        <div id="root" class="relative"></div>
     </body>
 </html>

--- a/local/index.html
+++ b/local/index.html
@@ -28,8 +28,31 @@
         <script src="./component.umd.js"></script>
         <script src="./index.js"></script>
         <link rel="stylesheet" href="./index.css" />
+        <style>
+            .local-env-banner {
+                background-color: #4285f4;
+                color: white;
+            }
+            .local-env-btn {
+                padding: 0.5rem 1rem;
+                border-radius: 5px;
+                border: 2px solid white;
+                background-color: inherit;
+                color: white;
+                font-weight: bold;
+            }
+            .local-env-btn:hover {
+                background-color: white;
+                color: #4285f4;
+            }
+        </style>
     </head>
     <body>
-        <div id="root"></div>
+        <div class="local-env-banner pa3">
+            <a href="./googleamp/#development=1"
+                ><button class="local-env-btn">View AMP page</button></a
+            >
+        </div>
+        <div id="root" class="relative"></div>
     </body>
 </html>

--- a/local/index.js
+++ b/local/index.js
@@ -14,26 +14,6 @@ window.ElementSdk.client.configure({
     tenant: tenantId
 });
 
-const globalStyles = {
-    color: {
-        background: '#fff',
-        link: '#333',
-        linkHover: '#333',
-        primary: '#333',
-        salePrice: '#333',
-        secondary: '#333',
-        text: '#333'
-    },
-    globalComponents: {},
-    typography: {
-        baseFontSize: '16px',
-        fontFamily: `"Roboto", sans-serif`,
-        headingFontFamily: `"Roboto", sans-serif`,
-        headingWeight: 700,
-        lineHeight: '1.15'
-    }
-};
-
 function createQueryParams() {
     const params = {};
     const searchParams = window.location.search;

--- a/local/index.js
+++ b/local/index.js
@@ -133,11 +133,20 @@ function renderBlock(data) {
     ReactDOM.render(block, root);
 }
 
+function setFallbackStoreInfo() {
+    clientUtils.client.setStoreInfo({});
+}
+
 // If tenant has been updated, set storeInformation
 if (!/\$YOUR_TENANT_ID/i.test(clientUtils.client.tenant)) {
-    clientUtils.client.storeInfo.get().then(storeInformation => {
-        clientUtils.client.setStoreInfo({ ...storeInformation });
-    });
+    clientUtils.client.storeInfo
+        .get()
+        .then(storeInformation => {
+            clientUtils.client.setStoreInfo({ ...storeInformation });
+        })
+        .catch(setFallbackStoreInfo);
+} else {
+    setFallbackStoreInfo();
 }
 
 window.onload = () =>

--- a/local/index.js
+++ b/local/index.js
@@ -1,5 +1,3 @@
-const blockModule = window.volBlock_local;
-
 const tenantId = '$YOUR_TENANT_ID';
 
 const localEnvPropOverrides = {
@@ -9,6 +7,8 @@ const localEnvPropOverrides = {
 const dataUtils = {
     isRendering: true
 };
+
+const blockModule = window.volBlock_local;
 
 window.ElementSdk.client.configure({
     tenant: tenantId

--- a/local/index.js
+++ b/local/index.js
@@ -2,9 +2,7 @@ const blockModule = window.volBlock_local;
 
 const tenantId = '$YOUR_TENANT_ID';
 
-const props = {
-    ...blockModule.defaultConfig,
-    queryParams: createQueryParams(),
+const localEnvPropOverrides = {
     text: 'Custom prop value for local testing'
 };
 
@@ -120,7 +118,9 @@ const clientUtils = {
 function configureBlock(data = {}) {
     const block = blockModule.block;
     return React.createElement(block, {
-        ...props,
+        ...blockModule.defaultConfig,
+        ...localEnvPropOverrides,
+        queryParams: createQueryParams(),
         utils: { ...clientUtils, ...serverUtils },
         joinClasses,
         data
@@ -144,6 +144,10 @@ window.onload = () =>
     blockModule
         .getDataProps(
             { ...clientUtils, ...serverUtils, ...dataUtils },
-            { ...props }
+            {
+                ...localEnvPropOverrides,
+                ...blockModule.defaultConfig,
+                queryParams: createQueryParams()
+            }
         )
         .then(renderBlock);

--- a/local/index.js
+++ b/local/index.js
@@ -134,8 +134,8 @@ window.onload = () =>
         .getDataProps(
             { ...clientUtils, ...serverUtils, ...dataUtils },
             {
-                ...localEnvPropOverrides,
                 ...blockModule.defaultConfig,
+                ...localEnvPropOverrides,
                 queryParams: createQueryParams()
             }
         )


### PR DESCRIPTION
#### Updates
- Adds additional default props to tests.
- Adds new AMP test file.
- Simplifies local env override props to remove default values that are always applied from where you place your local overrides.
- Add catch and fallback to function that gets/sets storeInformation.
- Removes now unused globalStyles.
- Moves local env tenant ID and prop overrides to the top of the `local/index.js` file.
- Adds navigation banner for moving back and forth between non-AMP and AMP pages.

#### Non-AMP page
![image](https://user-images.githubusercontent.com/8090481/81092803-c8196e00-8ec6-11ea-9b6c-14e709d65eca.png)

#### AMP page
![image](https://user-images.githubusercontent.com/8090481/81092834-d2d40300-8ec6-11ea-9b5c-8156c0fd94c8.png)
