### PR TITLE
V2E-4213: Include storeUrl in test data

### DIFF
--- a/local/index.js
+++ b/local/index.js
@@ -1,4 +1,5 @@
 const tenantId = '$YOUR_TENANT_ID';
+const storeUrl = "https://www.example.com";
 
 const localEnvPropOverrides = {
     text: 'Custom prop value for local testing'
@@ -85,7 +86,8 @@ const serverUtils = {
     addLink,
     addScript,
     isAmpRequest,
-    throwNotFound
+    throwNotFound,
+    storeUrl
 };
 
 const clientUtils = {

--- a/local/index.js
+++ b/local/index.js
@@ -1,5 +1,7 @@
 const tenantId = '$YOUR_TENANT_ID';
-const storeUrl = "https://www.example.com";
+// You can customize this value for local testing
+// if you use utils.storeUrl, but it's not required otherwise
+const storeUrl = 'http://localhost:4000/';
 
 const localEnvPropOverrides = {
     text: 'Custom prop value for local testing'


### PR DESCRIPTION
The scaffolding now includes an example `storeUrl` util that can be customized if needed.